### PR TITLE
Minor amends to response content collection to allow all tests to pass

### DIFF
--- a/collections/ResponseContent.postman_collection.json
+++ b/collections/ResponseContent.postman_collection.json
@@ -694,8 +694,8 @@
 							"script": {
 								"id": "35d6844f-ee5d-4520-a6a1-3d178404bcad",
 								"exec": [
-									"pm.test(\"Status code should be 200 OK\", function () {",
-									"    pm.response.to.have.status(200);",
+									"pm.test(\"Status code should be 201 Created\", function () {",
+									"    pm.response.to.have.status(201);",
 									"});",
 									""
 								],
@@ -784,8 +784,8 @@
 							"script": {
 								"id": "5589752e-c1a2-4920-8543-8964eae1d551",
 								"exec": [
-									"pm.test(\"Status code should be 200 OK\", function () {",
-									"    pm.response.to.have.status(200);",
+									"pm.test(\"Status code should be 201 Created\", function () {",
+									"    pm.response.to.have.status(201);",
 									"});",
 									""
 								],

--- a/collections/Smoke.postman_collection.json
+++ b/collections/Smoke.postman_collection.json
@@ -201,8 +201,8 @@
 							"script": {
 								"id": "a88cca40-a1ff-407c-9394-7d7fc1cffe64",
 								"exec": [
-									"pm.test(\"Status code should be 201 Created\", function () {",
-									"    pm.response.to.have.status(201);",
+									"pm.test(\"Status code should be 200 OK\", function () {",
+									"    pm.response.to.have.status(200);",
 									"});",
 									""
 								],
@@ -429,8 +429,8 @@
 							"script": {
 								"id": "3851f9b5-2371-4ab6-925f-4df1a5522073",
 								"exec": [
-									"pm.test(\"Status code should be 200 OK\", function () {",
-									"    pm.response.to.have.status(200);",
+									"pm.test(\"Status code should be 201 Created\", function () {",
+									"    pm.response.to.have.status(201);",
 									"});",
 									""
 								],
@@ -519,8 +519,8 @@
 							"script": {
 								"id": "355dc45a-08c3-4079-825b-bcefd795886c",
 								"exec": [
-									"pm.test(\"Status code should be 200 OK\", function () {",
-									"    pm.response.to.have.status(200);",
+									"pm.test(\"Status code should be 201 Created\", function () {",
+									"    pm.response.to.have.status(201);",
 									"});",
 									""
 								],


### PR DESCRIPTION
Hi Joannalaine,

Thankyou so much for sharing this Repo - its been really useful for me to learn from it as I'm trying to grow my Postman skills.

I always like to see all tests running and passing, and since the initial commit of your code I think Mark Winteringham must have amended a few of the endpoints on Restful Booker so that the response codes should come back as 201's instead of 200 and vice versa.

I've updated both collections in your repo to allow for this change (I'm a relative newbie to GitHub too so forgive me if pulling into your master isn't the right way of doing this, feedback welcome!).

Hope this helps,
Beth